### PR TITLE
removePlaceholder add carriage return in Firefox and IE

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -20,7 +20,7 @@
 			return false;
 
 		var value = data.replace( /[\n|\t]*/g, '' ).toLowerCase();
-		if ( !value || value == '<br>' || value == '<p>&nbsp;<br></p>' || value == '<p><br></p>' || value == '<p>&nbsp;</p>' || value == '&nbsp;' || value == ' ' || value == '&nbsp;<br>' || value == ' <br>' )
+		if ( !value || value == '<br>' || value == '<p>&nbsp;<br></p>' || value == '<p><br></p>' || value == '<div><br></div>' || value == '<p>&nbsp;</p>' || value == '&nbsp;' || value == ' ' || value == '&nbsp;<br>' || value == ' <br>' )
 			return true;
 
 		return false;
@@ -75,7 +75,18 @@
 			root.removeClass( 'placeholder' );
 			// fill it properly
 			if (CKEDITOR.dtd[ root.getName() ]['p']) {
-				root.setHtml( editor.enterMode === CKEDITOR.ENTER_P ? '<p><br/></p>' : (editor.enterMode === CKEDITOR.ENTER_DIV ? '<div><br/></div>' : '<br/>') );
+				var value = ' ';
+				if ( editor.enterMode === CKEDITOR.ENTER_P ){
+					value = '<p><br/></p>';
+				} else if (editor.enterMode === CKEDITOR.ENTER_DIV) {
+					value = '<div><br/><\/div>';
+				} else {
+					// FireFox prepends an additional line
+					if (!CKEDITOR.env.gecko){
+						value = '<br/>';
+					}
+				}
+				root.setHtml(value);
 				// Set caret in position
 				var range = new CKEDITOR.dom.range(editor.document);
 				range.moveToElementEditablePosition(root.getFirst(), true);

--- a/plugin.js
+++ b/plugin.js
@@ -75,15 +75,17 @@
 			root.removeClass( 'placeholder' );
 			// fill it properly
 			if (CKEDITOR.dtd[ root.getName() ]['p']) {
-				var value = ' ';
+				var value = '';
 				if ( editor.enterMode === CKEDITOR.ENTER_P ){
 					value = '<p><br/></p>';
 				} else if (editor.enterMode === CKEDITOR.ENTER_DIV) {
 					value = '<div><br/><\/div>';
 				} else {
+					// This is for CKEDITOR.ENTER_BR
+					value = '<br/>;
 					// FireFox prepends an additional line
-					if (!CKEDITOR.env.gecko){
-						value = '<br/>';
+					if (CKEDITOR.env.gecko || CKEDITOR.env.ie){
+						value = ' ';
 					}
 				}
 				root.setHtml(value);


### PR DESCRIPTION
function removePlaceholder adds a carriage return when CKE gets focus using Firefox in enterMode CKEDITOR_BR. Adding an additional check what browser is used and use ' ' for Firefox.