### PR TITLE
Update Angular support for CKEditor 4

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -195,6 +195,7 @@
 				editor.on('blur', addPlaceholder, null, placeholder);
 				editor.on('mode', addPlaceholder, null, placeholder);
 				editor.on('contentDom', addPlaceholder, null, placeholder);
+		                editor.on('dataReady', addPlaceholder, null, placeholder);
 
 				editor.on('focus', removePlaceholder);
 				editor.on('key', removePlaceholder);


### PR DESCRIPTION
Add new event handler since CKEditor 4 does not load the placeholder anymore when using it in Angular (11).